### PR TITLE
fix(#10): 대시보드 서비스 퍼블릭 라우팅 적용

### DIFF
--- a/apigateway-service/charts/templates/configmap.yml
+++ b/apigateway-service/charts/templates/configmap.yml
@@ -20,7 +20,7 @@ data:
           routes:
             # auth-service 라우팅
             - id: auth-service
-              uri: http://auth-service.auth-service.svc.cluster.local:80
+              uri: {{ .Values.config.spring.cloud.gateway.routes.uri.auth | default "http://auth-service.auth-service.svc.cluster.local:80" }}
               predicates:
                 - Path=/auth/**
                 - Method=GET,POST,PATCH,DELETE
@@ -28,16 +28,24 @@ data:
                 - RemoveRequestHeader=Cookie
             # user-service 라우팅
             - id: user-service
-              uri: http://user-service.user-service.svc.cluster.local:80
+              uri: {{ .Values.config.spring.cloud.gateway.routes.uri.user | default "http://user-service.user-service.svc.cluster.local:80" }}
               predicates:
                 - Path=/user/**
                 - Method=GET,POST,PATCH,DELETE
               filters:
                 - RemoveRequestHeader=Cookie
                 - AuthorizationHeaderFilter
-            # dashboard-service 라우팅
+            # dashboard-service 라우팅 - public 경로 (인증 없음)
+            - id: dashboard-service-public
+              uri: {{ .Values.config.spring.cloud.gateway.routes.uri.dashboard | default "http://dashboard-service.dashboard-service.svc.cluster.local:80" }}
+              predicates:
+                - Path=/dashboard/post-drive
+                - Method=POST
+              filters:
+                - RemoveRequestHeader=Cookie
+            # dashboard-service 라우팅 - 나머지 경로 (인증 필터 적용)
             - id: dashboard-service
-              uri: http://dashboard-service.dashboard-service.svc.cluster.local:80
+              uri: {{ .Values.config.spring.cloud.gateway.routes.uri.dashboard | default "http://dashboard-service.dashboard-service.svc.cluster.local:80" }}
               predicates:
                 - Path=/dashboard/**
                 - Method=GET,POST,PATCH,DELETE
@@ -46,7 +54,7 @@ data:
                 - AuthorizationHeaderFilter
             # llm-service 라우팅
             - id: llm-service
-              uri: http://llm-service.llm-service.svc.cluster.local:80
+              uri: {{ .Values.config.spring.cloud.gateway.routes.uri.llm | default "http://llm-service.llm-service.svc.cluster.local:80" }}
               predicates:
                 - Path=/llm/**
                 - Method=GET,POST,PATCH,DELETE
@@ -55,7 +63,7 @@ data:
                 - AuthorizationHeaderFilter
             # reward-service 라우팅
             - id: reward-service
-              uri: http://reward-service.reward-service.svc.cluster.local:80
+              uri: {{ .Values.config.spring.cloud.gateway.routes.uri.reward | default "http://reward-service.reward-service.svc.cluster.local:80" }}
               predicates:
                 - Path=/reward/**
                 - Method=GET,POST,PATCH,DELETE
@@ -64,7 +72,7 @@ data:
                 - AuthorizationHeaderFilter
             # admin-service 라우팅
             - id: admin-service
-              uri: http://admin-service.admin-service.svc.cluster.local:80
+              uri: {{ .Values.config.spring.cloud.gateway.routes.uri.admin | default "http://admin-service.admin-service.svc.cluster.local:80" }}
               predicates:
                 - Path=/admin/**
                 - Method=GET,POST,PATCH,DELETE
@@ -73,7 +81,7 @@ data:
                 - AuthorizationHeaderFilter
             # analysis-service 라우팅
             - id: analysis-service
-              uri: http://analysis-service.analysis-service.svc.cluster.local:80
+              uri: {{ .Values.config.spring.cloud.gateway.routes.uri.analysis | default "http://analysis-service.analysis-service.svc.cluster.local:80" }}
               predicates:
                 - Path=/analysis/**
                 - Method=GET,POST,PATCH,DELETE
@@ -82,7 +90,7 @@ data:
                 - AuthorizationHeaderFilter
             # agent-service 라우팅
             - id: agent-service
-              uri: http://agent-service.agent-service.svc.cluster.local:80
+              uri: {{ .Values.config.spring.cloud.gateway.routes.uri.agent | default "http://agent-service.agent-service.svc.cluster.local:80" }}
               predicates:
                 - Path=/agent/**
                 - Method=GET,POST,PATCH,DELETE

--- a/apigateway-service/charts/values.yaml
+++ b/apigateway-service/charts/values.yaml
@@ -23,3 +23,15 @@ config:
   spring:
     jwt:
       issuer: http://localhost
+    cloud:
+      gateway:
+        routes:
+          uri:
+            auth: http://auth-service.auth-service.svc.cluster.local:80
+            user: http://user-service.user-service.svc.cluster.local:80
+            dashboard: http://dashboard-service.dashboard-service.svc.cluster.local:80
+            llm: http://llm-service.llm-service.svc.cluster.local:80
+            reward: http://reward-service.reward-service.svc.cluster.local:80
+            admin: http://admin-service.admin-service.svc.cluster.local:80
+            analysis: http://analysis-service.analysis-service.svc.cluster.local:80
+            agent: http://agent-service.agent-service.svc.cluster.local:80


### PR DESCRIPTION
## 🔍 이슈

- Close #10 

---

## 📕 작업 내역

- 대시보드 서비스의 `/dashboard/post-drive` 엔드포인트를 퍼블릭으로 라우팅합니다.
- Values에 서비스별 uri를 추가하여 관리합니다.

---

## 📋 PR 유형

- [x] 기능 추가
- [ ] 버그 수정
- [ ] UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항 (오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제
- [ ] 파일 혹은 폴더 추가

---

## ⚠️ 추가적으로 설명할 내용

- 추가적으로 설명할 내용은 없습니다.